### PR TITLE
Add AppService caching test

### DIFF
--- a/src/app.service.spec.ts
+++ b/src/app.service.spec.ts
@@ -1,0 +1,31 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppService } from './app.service';
+import { ConfigService } from '@nestjs/config';
+import { API } from 'ynab';
+
+describe('AppService', () => {
+  let service: AppService;
+  let configService: { get: jest.Mock };
+
+  beforeEach(async () => {
+    configService = { get: jest.fn().mockReturnValue('FAKE_TOKEN') };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AppService,
+        { provide: ConfigService, useValue: configService },
+      ],
+    }).compile();
+
+    service = module.get<AppService>(AppService);
+  });
+
+  it('should reuse API instance', () => {
+    const first: API = service.getApiInstance();
+    const second: API = service.getApiInstance();
+
+    expect(first).toBeDefined();
+    expect(first).toBe(second);
+    expect(configService.get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -12,12 +12,15 @@ export class AppService {
     return 'Hello World!';
   }
 
-  getApiInstnace(): API {
-    const token = this.config.get('YNAB_API_KEY');
-    return this.instance || new API(token);
+  getApiInstance(): API {
+    if (!this.instance) {
+      const token = this.config.get('YNAB_API_KEY');
+      this.instance = new API(token);
+    }
+    return this.instance;
   }
   async getBudgets(): Promise<string> {
-    const { data } = await this.getApiInstnace().budgets.getBudgets();
+    const { data } = await this.getApiInstance().budgets.getBudgets();
 
     return data?.budgets
       .map(budget => {

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -4,7 +4,7 @@ import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class AppService {
-  private instance: API;
+  private instance?: API;
 
   constructor(private config: ConfigService) {}
 

--- a/src/telegram-bot/telegram-bot.service.spec.ts
+++ b/src/telegram-bot/telegram-bot.service.spec.ts
@@ -1,14 +1,27 @@
-import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { TelegramBotService } from './telegram-bot.service';
+
+jest.mock('telegraf', () => {
+  const TelegrafMock: any = jest.fn().mockImplementation(() => ({
+    use: jest.fn(),
+    command: jest.fn(),
+    launch: jest.fn(),
+    stop: jest.fn(),
+  }));
+  TelegrafMock.log = jest.fn();
+  return { Telegraf: TelegrafMock };
+});
 
 describe('TelegramBotService', () => {
   let service: TelegramBotService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [ConfigModule.forRoot()],
-      providers: [TelegramBotService],
+      providers: [
+        TelegramBotService,
+        { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue('FAKE_TOKEN') } },
+      ],
     }).compile();
 
     service = module.get<TelegramBotService>(TelegramBotService);


### PR DESCRIPTION
## Summary
- implement caching for `getApiInstance`
- mock Telegraf in TelegramBotService tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eb9a9ed54832cbc3120ce83a6d53f