### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-Telegram bot helps puting all your expenses into [YNAB](https://www.youneedabudget.com) at the end of the day. Built with NestJS. 
+Telegram bot helps putting all your expenses into [YNAB](https://www.youneedabudget.com) at the end of the day. Built with NestJS. 
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- fix typo in README

## Testing
- `BOT_TOKEN=dummy npm test` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684ec7f73710832c80aa922be760eb6c