### PR TITLE
Fix e2e tests

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
+import { TelegramBotService } from '../src/telegram-bot/telegram-bot.service';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
@@ -9,10 +10,22 @@ describe('AppController (e2e)', () => {
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      .overrideProvider(TelegramBotService)
+      .useValue({
+        setupBot: jest.fn(),
+        stopBot: jest.fn(),
+        addCommands: jest.fn(),
+        onApplicationShutdown: jest.fn(),
+      })
+      .compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
   });
 
   it('/ (GET)', () => {


### PR DESCRIPTION
## Summary
- mock `TelegramBotService` during e2e tests to avoid needing a bot token
- close app after each e2e test

## Testing
- `npm test`
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_684ec92885c8832c8d2029aabe69d213