### PR TITLE
Add Dev Container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Expense Tracker Bot",
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
     "postCreateCommand": "npm install",
     "forwardPorts": [3000],
     "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "name": "Expense Tracker Bot",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:0-22",
+    "postCreateCommand": "npm install",
+    "forwardPorts": [3000],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode"
+            ]
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Expense Tracker Bot",
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:0-22",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
     "postCreateCommand": "npm install",
     "forwardPorts": [3000],
     "customizations": {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ npm install
 
 ### Dev Containers
 
-This project includes a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) configuration. If you have the VS Code Dev Containers extension installed, you can open the repository in a containerized environment preconfigured with Node.js and common extensions. The container will install dependencies automatically and expose port `3000`.
+This project includes a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) configuration. With the VS Code Dev Containers extension, you can open the repository directly in a container running Node.js 22. The container installs dependencies automatically and exposes port `3000`.
 
 ## Running the app
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ npm install
 
 ### Dev Containers
 
-This project includes a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) configuration. With the VS Code Dev Containers extension, you can open the repository directly in a container running Node.js 22. The container installs dependencies automatically and exposes port `3000`.
+This project includes a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) configuration. With the VS Code Dev Containers extension, you can open the repository directly in a container running Node.js 22 with TypeScript. The container installs dependencies automatically and exposes port `3000`.
 
 ## Running the app
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Requires Node.js 22 LTS.
 $ npm install
 ```
 
+### Dev Containers
+
+This project includes a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) configuration. If you have the VS Code Dev Containers extension installed, you can open the repository in a containerized environment preconfigured with Node.js and common extensions. The container will install dependencies automatically and expose port `3000`.
+
 ## Running the app
 
 ```bash


### PR DESCRIPTION
## Summary
- add a VS Code devcontainer using Node 22
- document usage of Dev Containers in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f090aaa94832caf6db1fb6ac275a4